### PR TITLE
Fixes ServerSpec tests for Logstash config

### DIFF
--- a/examples/test.yml
+++ b/examples/test.yml
@@ -3,4 +3,4 @@
   hosts: all
   become: yes
   roles:
-    - role: ansible-role-riemann-2
+    - role: ansible-role-riemann

--- a/spec/riemann_server_spec.rb
+++ b/spec/riemann_server_spec.rb
@@ -29,10 +29,6 @@ describe user('riemann') do
   it { should belong_to_group 'riemann' }
 end
 
-describe file('/etc/logstash/conf.d') do
-  it { should_not exist }
-end
-
 riemann_directories = %w(
   /usr/share/riemann
   /etc/riemann


### PR DESCRIPTION
The tests currently test for absence of the logstash config directory, but another role may configure logstash on the same machine, so it's inappropriate to assume it'll be missing. The test passes when run inside this repo, but fails if testing an [integration of multiple logserver roles](https://github.com/freedomofpress/logserver-integration).
