### PR TITLE
Notifies handler if deb package install changed

### DIFF
--- a/tasks/packages.yml
+++ b/tasks/packages.yml
@@ -43,3 +43,4 @@
     dpkg_options: skip-same-version,force-confdef,force-confold
   register: riemann_install_result
   changed_when: "'dpkg: version {{ riemann_version }} of riemann already installed' not in riemann_install_result.stderr"
+  notify: restart riemann


### PR DESCRIPTION
Oversight from previous versions of the role: when moving between
versions of Riemann, the service is not restarted by notifying a role
handler. The postinst hooks for the deb package do not restart the
service, they merely ensure that it's running.

Closes #5.
