### PR TITLE
Makes deb package installation idempotent

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: Configures Riemann for alerting on Logstash events.
   company: Freedom of the Press Foundation (@freedomofpress)
   license: MIT
-  min_ansible_version: 1.9
+  min_ansible_version: 2
   platforms:
     - name: Debian
       versions:

--- a/spec/riemann_server_spec.rb
+++ b/spec/riemann_server_spec.rb
@@ -6,20 +6,7 @@ end
 
 describe service('riemann') do
   it { should be_running }
-end
-
-unless os[:family] == 'debian' && os[:release] >= '8'
-  # Debian 8 init script support a bit fishy in Serverspec.
-  # Will throw a NotImplementedError if attempted.
-  # NotImplementedError:
-  #   check_is_installed is not implemented in \
-  #   Specinfra::Command::Debian::V8::Service
-  describe service('riemann') do
-    it { should be_enabled }
-    it { should be_installed }
-  end
-  its('processes') { should eq ['java'] }
-
+  it { should be_enabled }
 end
 
 describe user('riemann') do

--- a/tasks/packages.yml
+++ b/tasks/packages.yml
@@ -40,7 +40,4 @@
   apt:
     deb: "{{ riemann_deb_file_fullpath }}"
     state: installed
-    dpkg_options: skip-same-version,force-confdef,force-confold
-  register: riemann_install_result
-  changed_when: "'dpkg: version {{ riemann_version }} of riemann already installed' not in riemann_install_result.stderr"
   notify: restart riemann


### PR DESCRIPTION
Bumps the required Ansible version to v2, when the apt modules's 'deb' parameter got smart enough to handle changed status without resorting to registering and inspecting the result.

Closes #7.
