### PR TITLE
Added Ubuntu 16.04 support

### DIFF
--- a/tasks/packages.yml
+++ b/tasks/packages.yml
@@ -1,9 +1,24 @@
 ---
-- name: Install Java.
+- name: Install OpenJDK7.
   become: yes
   apt:
     name: openjdk-7-jre-headless
     state: present
+  when: (ansible_distribution == "Debian")
+
+- name: Install OpenJDK7.
+  become: yes
+  apt:
+    name: openjdk-7-jre-headless
+    state: present
+  when: (ansible_distribution == "Ubuntu" and ansible_distribution_major_version <= "14")
+
+- name: Install OpenJDK8.
+  become: yes
+  apt:
+    name: openjdk-8-jre-headless
+    state: present
+  when: (ansible_distribution == "Ubuntu" and ansible_distribution_major_version >= "16")
 
 - name: Download Riemann deb package.
   become: yes


### PR DESCRIPTION
Seems that Ubuntu 16.04 dropped OpenJDK 7 - I’ve updated to add basic
logic to call for OpenJDK 8 on Ubuntu 16.04. We could potentially use
the meta package instead on Ubuntu which may be a little more elegant,
but didn’t want to make any large changes.
