### PR TITLE
Replace JRE 7 with "default JRE" package

### DIFF
--- a/tasks/packages.yml
+++ b/tasks/packages.yml
@@ -2,7 +2,7 @@
 - name: Install Java.
   become: yes
   apt:
-    name: openjdk-7-jre-headless
+    name: default-jre-headless
     state: present
 
 - name: Download Riemann deb package.


### PR DESCRIPTION
Depending on the JRE 7 package does not work in ubuntu xenial because
Java 7 is not included in the distribution. This commit uses the
"default JRE" package which is always available.

Closes #10
