### PR TITLE
Adds support for Ubuntu 16.04 (Xenial)

### DIFF
--- a/examples/test.yml
+++ b/examples/test.yml
@@ -1,4 +1,10 @@
 ---
+- name: Configure Python for Ansible.
+  gather_facts: no
+  hosts: all
+  tasks:
+    - raw: sudo apt-get install -y python python-apt
+
 - name: Test installation of riemann server role.
   hosts: all
   become: yes

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -11,7 +11,8 @@ galaxy_info:
         - jessie
     - name: Ubuntu
       versions:
-        - wily
+        - trusty
+        - xenial
   galaxy_tags:
     - alerting
     - logging

--- a/molecule.yml
+++ b/molecule.yml
@@ -10,6 +10,9 @@ vagrant:
     - name: trusty64
       box: ubuntu/trusty64
 
+    - name: xenial64
+      box: ubuntu/xenial64
+
   providers:
     - name: virtualbox
       type: virtualbox

--- a/tasks/packages.yml
+++ b/tasks/packages.yml
@@ -4,6 +4,8 @@
   apt:
     name: default-jre-headless
     state: present
+    update_cache: yes
+    cache_valid_time: 3600
 
 - name: Download Riemann deb package.
   become: yes

--- a/tasks/packages.yml
+++ b/tasks/packages.yml
@@ -2,7 +2,7 @@
 - name: Install Java.
   become: yes
   apt:
-    name: openjdk-7-jre-headless
+    name: default-jre-headless
     state: present
 
 - name: Download Riemann deb package.


### PR DESCRIPTION
The Ubuntu 16.04 repos no longer serve the deprecated `openjdk-7-jre-headless` package, deferring instead to the metapackage `default-jre-headless` that tracks the most recent version. This metapackage works similarly on other Debian derivatives.

Updates the Molecule config to include Xenial as a test host. Since Xenial uses python3 by default, the testing playbook now has a `raw` task in a separate play to bootstrap the host for Ansible support. This is necessary for automated local testing.

Running `molecule test --platform all` now shows passing idempotence and Serverspec tests for Debian Jessie, Ubuntu Trusty, and Ubuntu Xenial.

Incorporates and therefore closes #11. Closes #10. Supersedes and therefore closes #9.
