### PR TITLE
Allow over-ride of JVM utilized

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -33,3 +33,6 @@ riemann_slack_tag: slack_alert
 
 # Disable verbose logging, useful for standing up the server.
 riemann_debug_logging: false
+
+# Allow override ability of installed JVM
+riemann_jvm_pkg: default-jre-headless

--- a/tasks/packages.yml
+++ b/tasks/packages.yml
@@ -2,7 +2,7 @@
 - name: Install Java.
   become: yes
   apt:
-    name: default-jre-headless
+    name: "{{ riemann_jvm_pkg }}"
     state: present
     update_cache: yes
     cache_valid_time: 3600


### PR DESCRIPTION
The documentation for Riemann doesnt narrow down to a particular Java
version and indicates you could get better mileage with other versions.
Allow downstream playbook to over-ride the JVM installed for customization.