### PR TITLE
Add optional tasks to override default templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,21 @@ riemann_slack_tag: slack_alert
 
 # Disable verbose logging, useful for standing up the server.
 riemann_debug_logging: false
+
+# Allow override ability of installed JVM
+riemann_jvm_pkg: default-jre-headless
+
+# Remote config directories to be created. Config files, via fileglob
+# or otherwise, will be added to these directories.
+riemann_create_folders:
+  - "conf.d"
+  - "utils"
+
+riemann_default_templates:
+  - src: riemann.config.j2
+    dest: /etc/riemann/riemann.config
+  - src: slack-alerts.clj.j2
+    dest: /etc/riemann/conf.d/slack-alerts.clj
 ```
 
 Example Playbook

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -37,6 +37,8 @@ riemann_debug_logging: false
 # Allow override ability of installed JVM
 riemann_jvm_pkg: default-jre-headless
 
+# Remote config directories to be created. Config files, via fileglob
+# or otherwise, will be added to these directories.
 riemann_create_folders:
   - "conf.d"
   - "utils"
@@ -47,6 +49,9 @@ riemann_default_templates:
   - src: slack-alerts.clj.j2
     dest: /etc/riemann/conf.d/slack-alerts.clj
 
+# Override the default template with a unified config file.
 riemann_optional_baseconfig: ""
+# Provide additional config files, via fileglob. Files and templates
+# will be transfered using `copy` and `template`, respectively.
 riemann_optional_addfiles: []
 riemann_optional_addtemplates: []

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -36,3 +36,17 @@ riemann_debug_logging: false
 
 # Allow override ability of installed JVM
 riemann_jvm_pkg: default-jre-headless
+
+riemann_create_folders:
+  - "conf.d"
+  - "utils"
+
+riemann_default_templates:
+  - src: riemann.config.j2
+    dest: /etc/riemann/riemann.config
+  - src: slack-alerts.clj.j2
+    dest: /etc/riemann/conf.d/slack-alerts.clj
+
+riemann_optional_baseconfig: ""
+riemann_optional_addfiles: []
+riemann_optional_addtemplates: []

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -18,7 +18,6 @@
     owner: riemann
     group: riemann
     mode: "0644"
-  when: "riemann_default_templates != []"
   with_items: "{{ riemann_default_templates }}"
   notify: restart riemann
 
@@ -39,7 +38,6 @@
     owner: riemann
     group: riemann
     mode: "0644"
-  when: "riemann_optional_addfiles"
   with_fileglob: "{{ riemann_optional_addfiles }}"
   notify: restart riemann
 
@@ -51,7 +49,6 @@
     group: riemann
     mode: "0644"
   notify: restart riemann
-  when: "riemann_optional_addtemplates"
   with_fileglob: "{{ riemann_optional_addtemplates }}"
 
 - name: Start riemann service.

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -4,29 +4,55 @@
   # here rather than the more typical root:root 0644.
 - name: Create configuration directory.
   file:
-    path: /etc/riemann/conf.d
+    path: "/etc/riemann/{{ item }}"
     state: directory
     owner: riemann
     group: riemann
     mode: "0755"
+  with_items: "{{ riemann_create_folders }}"
 
-- name: Create configuration file.
+- name: Copy over role default templates
   template:
-    src: riemann.config.j2
+    src: "{{ item.src }}"
+    dest: "{{ item.dest }}"
+    owner: riemann
+    group: riemann
+    mode: "0644"
+  when: "riemann_default_templates != []"
+  with_items: "{{ riemann_default_templates }}"
+  notify: restart riemann
+
+- name: Copy non-template riemann.config
+  copy:
+    src: "{{ riemann_optional_baseconfig }}"
     dest: /etc/riemann/riemann.config
     owner: riemann
     group: riemann
     mode: "0644"
+  when: "riemann_optional_baseconfig != ''"
   notify: restart riemann
 
-- name: Copy extra configuration files.
+- name: Copy additional files by fileglob
+  copy:
+    src: "{{ item }}"
+    dest: /etc/riemann/conf.d/
+    owner: riemann
+    group: riemann
+    mode: "0644"
+  when: "riemann_optional_addfiles"
+  with_fileglob: "{{ riemann_optional_addfiles }}"
+  notify: restart riemann
+
+- name: Copy additional templates by fileglob
   template:
-    src: slack-alerts.clj.j2
-    dest: /etc/riemann/conf.d/slack-alerts.clj
+    src: "{{ item }}"
+    dest: /etc/riemann/utils/
     owner: riemann
     group: riemann
     mode: "0644"
   notify: restart riemann
+  when: "riemann_optional_addtemplates"
+  with_fileglob: "{{ riemann_optional_addtemplates }}"
 
 - name: Start riemann service.
   service:


### PR DESCRIPTION
This is a little hacky but allows breaking out core riemann.config,
subsequent files, and then templated files. All off by default.