### PR TITLE
Bumps default version 0.2.11 -> 0.2.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Role Variables
 ```yaml
 # Version of the deb package to install. You can view the most
 # recent release here: https://github.com/riemann/riemann/releases
-riemann_version: "0.2.11"
+riemann_version: "0.2.13"
 
 riemann_download_directory: /usr/local/src
 riemann_download_url: "https://aphyr.com/riemann/riemann_{{ riemann_version }}_all.deb"

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Role Variables
 riemann_version: "0.2.13"
 
 riemann_download_directory: /usr/local/src
-riemann_download_url: "https://aphyr.com/riemann/riemann_{{ riemann_version }}_all.deb"
+riemann_download_url: "https://github.com/riemann/riemann/releases/download/{{riemann_version}}/riemann_{{riemann_version}}_all.deb"
 riemann_deb_file_fullpath: "{{ riemann_download_directory }}/{{ riemann_download_url | basename }}"
 
 # The checksum file will be downloaded separately and the MD5sum (best that's offered)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # Version of the deb package to install. You can view the most
 # recent release here: https://github.com/riemann/riemann/releases
-riemann_version: "0.2.11"
+riemann_version: "0.2.13"
 
 riemann_download_directory: /usr/local/src
 riemann_download_url: "https://aphyr.com/riemann/riemann_{{ riemann_version }}_all.deb"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,7 +4,7 @@
 riemann_version: "0.2.13"
 
 riemann_download_directory: /usr/local/src
-riemann_download_url: "https://aphyr.com/riemann/riemann_{{ riemann_version }}_all.deb"
+riemann_download_url: "https://github.com/riemann/riemann/releases/download/{{riemann_version}}/riemann_{{riemann_version}}_all.deb"
 riemann_deb_file_fullpath: "{{ riemann_download_directory }}/{{ riemann_download_url | basename }}"
 
 # The checksum file will be downloaded separately and the MD5sum (best that's offered)


### PR DESCRIPTION
See changelog [0] for details.

[0] https://github.com/riemann/riemann/blob/fe40f86caa5fb1bf56da781224fb7ed487bc8c2b/CHANGES.markdown#version-0213

Closes #16. 