### PR TITLE
Hacky re-organization to misc. deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,12 +55,22 @@ riemann_jvm_pkg: default-jre-headless
 riemann_create_folders:
   - "conf.d"
   - "utils"
+  - "vars"
 
 riemann_default_templates:
   - src: riemann.config.j2
     dest: /etc/riemann/riemann.config
   - src: slack-alerts.clj.j2
     dest: /etc/riemann/conf.d/slack-alerts.clj
+
+# Override the default template with a unified config file.
+riemann_optional_baseconfig: ""
+# Provide additional config files, via fileglob.
+riemann_optional_addconfs: []
+riemann_optional_addutils: []
+
+# Key/values that riemann can import and utilize
+riemann_alerts_auth_map: {}
 ```
 
 Example Playbook

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -42,6 +42,7 @@ riemann_jvm_pkg: default-jre-headless
 riemann_create_folders:
   - "conf.d"
   - "utils"
+  - "vars"
 
 riemann_default_templates:
   - src: riemann.config.j2
@@ -51,7 +52,9 @@ riemann_default_templates:
 
 # Override the default template with a unified config file.
 riemann_optional_baseconfig: ""
-# Provide additional config files, via fileglob. Files and templates
-# will be transfered using `copy` and `template`, respectively.
-riemann_optional_addfiles: []
-riemann_optional_addtemplates: []
+# Provide additional config files, via fileglob.
+riemann_optional_addconfs: []
+riemann_optional_addutils: []
+
+# Key/values that riemann can import and utilize
+riemann_alerts_auth_map: {}

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -21,7 +21,7 @@
   with_items: "{{ riemann_default_templates }}"
   notify: restart riemann
 
-- name: Copy non-template riemann.config
+- name: Copy riemann.config
   copy:
     src: "{{ riemann_optional_baseconfig }}"
     dest: /etc/riemann/riemann.config
@@ -31,25 +31,35 @@
   when: "riemann_optional_baseconfig != ''"
   notify: restart riemann
 
-- name: Copy additional files by fileglob
+- name: Copy additional configuration files
   copy:
     src: "{{ item }}"
-    dest: /etc/riemann/conf.d/
+    dest: "/etc/riemann/conf.d"
     owner: riemann
     group: riemann
     mode: "0644"
-  with_fileglob: "{{ riemann_optional_addfiles }}"
+  with_fileglob: "{{ riemann_optional_addconfs }}"
   notify: restart riemann
 
-- name: Copy additional templates by fileglob
-  template:
+- name: Copy additional clojure utility scripts
+  copy:
     src: "{{ item }}"
     dest: /etc/riemann/utils/
     owner: riemann
     group: riemann
     mode: "0644"
   notify: restart riemann
-  with_fileglob: "{{ riemann_optional_addtemplates }}"
+  with_fileglob: "{{ riemann_optional_addutils }}"
+
+- name: Copy hashmap variables
+  template:
+    src: config.clj.j2
+    dest: /etc/riemann/vars/config.clj
+    owner: riemann
+    group: riemann
+    mode: "0644"
+  when: riemann_alerts_auth_map != {}
+  notify: restart riemann
 
 - name: Start riemann service.
   service:

--- a/templates/config.clj.j2
+++ b/templates/config.clj.j2
@@ -1,0 +1,11 @@
+(ns vars.config
+"Utilities configuration file")
+
+(def config
+{% raw %}{{% endraw %}
+{% for k,v in riemann_alerts_auth_map.iteritems() %}
+ :{{ k }} "{{ v }}"
+{% endfor %}
+
+{% raw %}}{% endraw %}
+)


### PR DESCRIPTION
This ... yeah.. it's kind of .... yeah the lack of DRY kind of bothers me
over the various config files. Might have to do some future re-organization but
for now this solve the problems we are having.

Experimenting with different riemann config layouts through variables.
Added support for a large hashmap `vars.config` for other clojure
files to import from.