### PR TITLE
Task name cleanup, fix for hashmap configuration

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -60,6 +60,7 @@
     mode: "0644"
   when: riemann_alerts_auth_map != {}
   notify: restart riemann
+  tags: hashmap
 
 - name: Start riemann service.
   service:

--- a/templates/config.clj.j2
+++ b/templates/config.clj.j2
@@ -6,6 +6,8 @@
 {% for k,v in riemann_alerts_auth_map.iteritems() %}
  :{{ k }} "{{ v }}"
 {% endfor %}
-
+{% for k,v in riemann_alerts_auth_map_int.iteritems() %}
+ :{{ k }} {{ v | to_json }}
+{% endfor %}
 {% raw %}}{% endraw %}
 )


### PR DESCRIPTION
The name cleanup of tasks is self-explanatory. The bigger issue was the
configuration hash issue. In particular, I ran into syntax issues when ansible
was doing the jinja dropping of particular variables. So specifically the issue
is that all strings need to be quoted, and all integers need to be unquoted for
clojure/riemann to interpret them correctly. I was unable to do this
cleanly/easily without breaking the hash map into two separate variables. I'm
happy for someone else to take a stab at it but I timeboxed myself and didnt
think it was worth the additional effort :|