### PR TITLE
Bump Riemann version from 0.2.13 to 0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Role Variables
 ```yaml
 # Version of the deb package to install. You can view the most
 # recent release here: https://github.com/riemann/riemann/releases
-riemann_version: "0.2.13"
+riemann_version: "0.3.0"
 
 riemann_download_directory: /usr/local/src
 riemann_download_url: "https://github.com/riemann/riemann/releases/download/{{riemann_version}}/riemann_{{riemann_version}}_all.deb"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # Version of the deb package to install. You can view the most
 # recent release here: https://github.com/riemann/riemann/releases
-riemann_version: "0.2.13"
+riemann_version: "0.3.0"
 
 riemann_download_directory: /usr/local/src
 riemann_download_url: "https://github.com/riemann/riemann/releases/download/{{riemann_version}}/riemann_{{riemann_version}}_all.deb"


### PR DESCRIPTION
Still need to test this to make sure there's no incompatibilities and the configuration passes... but this is the start of the PR.