### PR TITLE
Fix deprecation warnings with include_tasks

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,4 @@
 ---
-- include: packages.yml
+- include_tasks: packages.yml
 
-- include: configure.yml
+- include_tasks: configure.yml


### PR DESCRIPTION
No newer version of Riemann available. Also, it's in repos so the download strategy of this role is quirky.